### PR TITLE
Fix the call of get_chain with keyword arguments

### DIFF
--- a/pykdl_utils/src/pykdl_utils/kdl_kinematics.py
+++ b/pykdl_utils/src/pykdl_utils/kdl_kinematics.py
@@ -143,7 +143,8 @@ class KDLKinematics(object):
     ##
     # @return List of link names in the kinematic chain.
     def get_link_names(self, joints=False, fixed=True):
-        return self.urdf.get_chain(self.base_link, self.end_link, joints, fixed)
+        return self.urdf.get_chain(self.base_link, self.end_link, 
+                                   joints=joints, fixed=fixed)
 
     ##
     # @return List of joint names in the kinematic chain.


### PR DESCRIPTION
``get_link_names`` returns an empty list, which breaks ``FK`` and ``forward`` when ``end_link`` is provided. This happens because ``get_chain`` is called in ``get_link_names`` with the wrong number of arguments.